### PR TITLE
Fix exception handling in logging middleware

### DIFF
--- a/app/Core/Logger/Message/LoggerMessageFactory.php
+++ b/app/Core/Logger/Message/LoggerMessageFactory.php
@@ -2,9 +2,9 @@
 
 namespace App\Core\Logger\Message;
 
-use Exception;
 use Illuminate\Http\Request;
 use Stringable;
+use Throwable;
 
 class LoggerMessageFactory implements LoggerMessageFactoryContract
 {
@@ -13,7 +13,7 @@ class LoggerMessageFactory implements LoggerMessageFactoryContract
     ) {
     }
 
-    public function makeHTTPError(Exception $e): Stringable
+    public function makeHTTPError(Throwable $e): Stringable
     {
         return new LoggingHTTPError(
             $this->request,

--- a/app/Core/Logger/Message/LoggerMessageFactoryContract.php
+++ b/app/Core/Logger/Message/LoggerMessageFactoryContract.php
@@ -2,12 +2,12 @@
 
 namespace App\Core\Logger\Message;
 
-use Exception;
 use Stringable;
+use Throwable;
 
 interface LoggerMessageFactoryContract
 {
-    public function makeHTTPError(Exception $e): Stringable;
+    public function makeHTTPError(Throwable $e): Stringable;
 
     public function makeHTTPStart(
         string $message,

--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -12,7 +12,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\GetRefreshTokenRequest;
 use App\Http\Requests\Auth\LoginRequest;
 use App\Http\Requests\Auth\LogoutRequest;
-use Exception;
+use Throwable;
 
 class AuthController extends Controller
 {
@@ -31,7 +31,7 @@ class AuthController extends Controller
             ]);
         } catch (InvalidCredentialException $e) {
             throw new UnauthorizedException($e->exceptionMessage);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             throw new InternalServerErrorException(new ExceptionMessageGeneric);
         }
     }
@@ -44,7 +44,7 @@ class AuthController extends Controller
             return response()->noContent();
         } catch (JWTException $e) {
             throw new UnauthorizedException($e->exceptionMessage);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             throw new InternalServerErrorException(new ExceptionMessageGeneric);
         }
     }
@@ -59,7 +59,7 @@ class AuthController extends Controller
             ]);
         } catch (JWTException $e) {
             throw new UnauthorizedException($e->exceptionMessage);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             throw new InternalServerErrorException(new ExceptionMessageGeneric);
         }
     }

--- a/app/Http/Controllers/Healthcheck/HealthcheckController.php
+++ b/app/Http/Controllers/Healthcheck/HealthcheckController.php
@@ -11,6 +11,7 @@ use App\Http\Requests\Healthcheck\HealthcheckRequest;
 use Exception;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Log;
+use Throwable;
 
 class HealthcheckController extends Controller
 {
@@ -47,7 +48,7 @@ class HealthcheckController extends Controller
             return response()
                 ->json($status->toArray())
                 ->setStatusCode(Response::HTTP_SERVICE_UNAVAILABLE);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             Log::error($this->logFormatter->makeHTTPError($e));
             throw new InternalServerErrorException(new ExceptionMessageGeneric);
         }

--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -15,8 +15,8 @@ use App\Http\Requests\User\GetMyInfoRequest;
 use App\Http\Requests\User\GetUserRequest;
 use App\Http\Requests\User\UpdateUserRequest;
 use App\Http\Resources\User\UserResource;
-use Exception;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 class UserController extends Controller
 {
@@ -31,7 +31,7 @@ class UserController extends Controller
             $this->core->delete($request);
 
             return response()->json([], Response::HTTP_NO_CONTENT);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             throw new InternalServerErrorException(new ExceptionMessageGeneric);
         }
     }
@@ -42,7 +42,7 @@ class UserController extends Controller
             $users = $this->core->getAll($request);
 
             return UserResource::collection($users);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             throw new InternalServerErrorException(new ExceptionMessageGeneric);
         }
     }
@@ -55,7 +55,7 @@ class UserController extends Controller
             return UserResource::make($user)
                 ->response()
                 ->setStatusCode(Response::HTTP_OK);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             throw new InternalServerErrorException(new ExceptionMessageGeneric);
         }
     }
@@ -68,7 +68,7 @@ class UserController extends Controller
             return UserResource::make($user)
                 ->response()
                 ->setStatusCode(Response::HTTP_OK);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             throw new InternalServerErrorException(new ExceptionMessageGeneric);
         }
     }
@@ -83,7 +83,7 @@ class UserController extends Controller
                 ->setStatusCode(Response::HTTP_CREATED);
         } catch (UserEmailDuplicatedException $e) {
             throw new ConflictException($e->exceptionMessage);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             throw new InternalServerErrorException(new ExceptionMessageGeneric);
         }
     }
@@ -96,7 +96,7 @@ class UserController extends Controller
             return UserResource::make($user);
         } catch (UserEmailDuplicatedException $e) {
             throw new ConflictException($e->exceptionMessage);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             throw new InternalServerErrorException(new ExceptionMessageGeneric);
         }
     }

--- a/app/Http/Middleware/LoggingMiddleware.php
+++ b/app/Http/Middleware/LoggingMiddleware.php
@@ -48,7 +48,7 @@ class LoggingMiddleware
         $exceptionMessage = $this->logFormatter->makeHTTPError(
             $exception->getPrevious() ?? $exception
         );
-        if ($exception->getCode() < 500) {
+        if ($this->isHTTPClientError($exception->getCode())) {
             Log::warning($exceptionMessage);
 
             return $response;
@@ -64,5 +64,10 @@ class LoggingMiddleware
         return collect($input)
             ->reject(fn ($value, $key) => collect(['password'])->contains($key))
             ->toArray();
+    }
+
+    protected function isHTTPClientError(int $httpCode): bool
+    {
+        return $httpCode > 399 && $httpCode < 500;
     }
 }


### PR DESCRIPTION
Sometime response will have `Error` instead of `Exception`, that's why it's better for us to use `Throwable` interface as parameter since both `Error` and `Exception` is implementing `Throwable` interface.

Also, make a generic exception that thrown by the bug (system itself) logged as **ERROR**. Before this, if we have generic exception with exception code of `0`, the middleware will mark the logged message as **warning**.